### PR TITLE
Upgrade to 1.25.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile to build docker-compose for aarch64
-FROM arm64v8/python:3.6.5-stretch
+FROM arm64v8/python:3.7.7-stretch
 
 # Add env
 ENV LANG C.UTF-8
@@ -9,15 +9,16 @@ COPY ./vendor/qemu-bin /usr/bin/
 RUN [ "cross-build-start" ]
 
 # Set the versions
-ENV DOCKER_COMPOSE_VER 1.22.0
+ENV DOCKER_COMPOSE_VER 1.25.4
 # docker-compose requires pyinstaller 3.3.1 (check github.com/docker/compose/requirements-build.txt)
 # If this changes, you may need to modify the version of "six" below
-ENV PYINSTALLER_VER 3.3.1
+ENV PYINSTALLER_VER 3.6
 # "six" is needed for PyInstaller. v1.11.0 is the latest as of PyInstaller 3.3.1
-ENV SIX_VER 1.11.0
+ENV SIX_VER 1.14.0
 
 # Install dependencies
 # RUN apt-get update && apt-get install -y
+RUN pip install --upgrade pip setuptools wheel
 RUN pip install six==$SIX_VER
 
 # Compile the pyinstaller "bootloader"
@@ -34,8 +35,8 @@ RUN git clone https://github.com/docker/compose.git . \
 
 # Run the build steps (taken from github.com/docker/compose/script/build/linux-entrypoint)
 RUN mkdir ./dist \
-    && pip install -q -r requirements.txt -r requirements-build.txt \
-    && ./script/build/write-git-sha \
+    && echo $(./script/build/write-git-sha) > compose/GITSHA \
+    && pip -v install -q -r requirements.txt -r requirements-build.txt \
     && pyinstaller docker-compose.spec \
     && mv dist/docker-compose ./docker-compose-$(uname -s)-$(uname -m)
 


### PR DESCRIPTION
Doesn't look like this repo is maintained anymore, I've released the binary over on the fork on my own repo:

https://github.com/nefilim/docker-compose-aarch64/releases